### PR TITLE
feat: copy image URL list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,6 +101,16 @@ function App() {
     })
   }, [])
 
+  const copyUrls = useCallback(async () => {
+    const urls = images.map(img => img.url).join('\n')
+    try {
+      await navigator.clipboard.writeText(urls)
+      alert('Image URLs copied to clipboard')
+    } catch {
+      alert('Failed to copy image URLs')
+    }
+  }, [images])
+
   const openViewer = useCallback((index: number) => {
     setViewerIndex(index)
   }, [])
@@ -182,6 +192,14 @@ function App() {
                 className="px-3 py-2 rounded-md bg-blue-600 text-white text-sm font-medium shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
               >
                 Shuffle
+              </button>
+              <button
+                type="button"
+                onClick={copyUrls}
+                disabled={images.length === 0}
+                className="px-3 py-2 rounded-md bg-green-600 text-white text-sm font-medium shadow hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Copy URLs
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add function to copy list of bookmarked image URLs to clipboard
- expose Copy URLs button in header for quick access

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a774c19774832394b091f8c4b25387